### PR TITLE
fix(maven-flow): escape commit message via env var

### DIFF
--- a/maven-flow/action.yml
+++ b/maven-flow/action.yml
@@ -46,9 +46,12 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Echo commit message
+      env:
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        COMMIT_ID: ${{ github.event.head_commit.id }}
       run: |
-        echo "Commit message: ${{ github.event.head_commit.message }}"
-        echo "Commit id: ${{ github.event.head_commit.id }}"
+        echo "Commit message: $COMMIT_MESSAGE"
+        echo "Commit id: $COMMIT_ID"
       shell: bash
 
     - name: Set up JDK


### PR DESCRIPTION
## Summary
- The `Echo commit message` step in `maven-flow/action.yml` interpolated `github.event.head_commit.message` directly into a bash `echo`. When a commit message contained an unescaped double quote followed by an apostrophe (e.g. `"I don't get anything"`), the outer `"..."` was closed early and the lone `'` left the shell waiting for a match — every build with such a commit message failed before Maven even started (`unexpected EOF while looking for matching '`).
- Pass `COMMIT_MESSAGE` / `COMMIT_ID` through `env:` and reference them as `\$COMMIT_MESSAGE` / `\$COMMIT_ID` in the script — the value never touches the shell parser, so any character (quotes, backticks, `\$`, newlines) is safe.

## Why
- Real failure that just blocked the notification-service release: https://github.com/wlnob/notification-service/actions/runs/27280696415
- Same well-known GitHub Actions script-injection pitfall documented by GitHub Security Lab — fixing it at the action layer protects every consuming service.

## Test plan
- [ ] Re-run the failed notification-service workflow once this PR merges and verify the `Echo commit message` step succeeds with the existing commit `fix(BCJ-19447): send shift-start reminders via MyStaffler Firebase (#17)`.
- [ ] Spot-check one other service that uses `wlnob/actions/maven-flow@master` to confirm there's no regression in the echoed output format.